### PR TITLE
support .terraform-version file

### DIFF
--- a/get-terraform-version/README.md
+++ b/get-terraform-version/README.md
@@ -59,6 +59,8 @@ jobs:
 
 ### Custom directory, file and pattern
 
+The following example extracts the Terraform version from the `.terraform-version` file, which is used by tools such as [tenv](https://github.com/tofuutils/tenv) and [tfenv](https://github.com/tfutils/tfenv). In this example, the file is located in a custom directory, `path/to/terraform/config`, and contains only the Terraform version. As a result, the pattern `^(.*)$` is used to match its content.
+
 ```yaml
 - name: Get Terraform version
   id: terraform_version
@@ -67,4 +69,16 @@ jobs:
     directory: path/to/terraform/config
     file: ".terraform-version"
     pattern: "^(.*)$"
+```
+
+The next example extracts the Terraform version from the [asdf](https://asdf-vm.com/) configuration file `.tool-versions`. In this example, the configuration file is also located in a custom directory, `path/to/terraform/config`. The pattern used matches the [configuration](https://asdf-vm.com/manage/configuration.html) syntax of the `asdf` tool.
+
+```yaml
+- name: Get Terraform version
+  id: terraform_version
+  uses: cloudeteer/actions/get-terraform-version@main
+  with:
+    directory: path/to/terraform/config
+    file: ".tool-versions"
+    pattern: "^terraform (.*)$"
 ```

--- a/get-terraform-version/README.md
+++ b/get-terraform-version/README.md
@@ -1,10 +1,10 @@
 # Set environment variables
 
-This GitHub Action allows you to extract the `required_version` of Terraform specified in your configuration and use it as an output within your GitHub Actions workflow. This is useful for ensuring that workflows adhere to the same Terraform version specified in the project configuration.
+This GitHub Action allows you to extract the version of Terraform specified in your configuration and use it as an output within your GitHub Actions workflow. This is useful for ensuring that workflows adhere to the same Terraform version specified in the project configuration.
 
 ## How It Works
 
-1. This action reads each file in a directory for the `required_version` directive.
+1. This action reads given files in a directory for Terraform version directive.
 2. It extracts the version and sets it as an output.
 3. You can then use this output in other steps within your workflow.
 
@@ -16,14 +16,16 @@ This GitHub Action allows you to extract the `required_version` of Terraform spe
 
 ## Inputs
 
-| Input Name  | Required | Default | Description                                                      |
-| ----------- | -------- | ------- | ---------------------------------------------------------------- |
-| `directory` | Yes      | `.`     | The directory path to search for the `required_version` setting. |
+| Input Name  | Required | Default                              | Description                                                     |
+|-------------|----------|--------------------------------------|-----------------------------------------------------------------|
+| `directory` | No       | `.`                                  | The directory path to search for the Terraform version setting. |
+| `file`      | No       | `*.tf`                               | The file pattern to search for the Terraform version setting.   |
+| `pattern`   | No       | `^\s*required_version\s*=\s*"(.*?)"` | The pattern to search for the Terraform version setting.        |
 
 ## Outputs
 
 | Output Name        | Description                                                            |
-| ------------------ | ---------------------------------------------------------------------- |
+|--------------------|------------------------------------------------------------------------|
 | `required_version` | The `required_version` of Terraform as specified in the configuration. |
 
 ## Usage
@@ -53,4 +55,16 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ steps.terraform_version.output.required_version }}
+```
+
+### Custom directory, file and pattern
+
+```yaml
+- name: Get Terraform version
+  id: terraform_version
+  uses: cloudeteer/actions/get-terraform-version@main
+  with:
+    directory: path/to/terraform/config
+    file: ".terraform-version"
+    pattern: "^(.*)$"
 ```

--- a/get-terraform-version/action.yaml
+++ b/get-terraform-version/action.yaml
@@ -1,13 +1,18 @@
 name: Extract Terraform Version
-description: Outputs the `required_version` of Terraform from a specified configuration file.
+description: Outputs version of Terraform from a specified configuration file.
 inputs:
   directory:
-    required: true
-    description: The file path to the configuration file containing the `required_version` setting.
-    default: .
+    required: false
+    description: The file path to the configuration file containing the terraform version setting.
+  file:
+    required: false
+    description: The filename (or wildcard filter) of the configuration file containing the terraform version setting.
+  pattern:
+    required: false
+    description: The pattern to search for in the configuration file.
 outputs:
   required_version:
-    description: The `required_version` of Terraform as specified in the configuration file.
+    description: The version of Terraform as specified in the configuration file.
     value: ${{ steps.main.outputs.required_version }}
 runs:
   using: composite

--- a/get-terraform-version/action.yaml
+++ b/get-terraform-version/action.yaml
@@ -3,16 +3,16 @@ description: Outputs version of Terraform from a specified configuration file.
 inputs:
   directory:
     required: false
-    description: The file path to the configuration file containing the terraform version setting.
+    description: The directory path to the folder containing the configuration file with the Terraform version setting.
   file:
     required: false
-    description: The filename (or wildcard filter) of the configuration file containing the terraform version setting.
+    description: The filename (or glob pattern) of the configuration file(s) that contain the Terraform version setting.
   pattern:
     required: false
-    description: The pattern to search for in the configuration file.
+    description: The regex pattern used to search for the Terraform version in the configuration file.
 outputs:
   required_version:
-    description: The version of Terraform as specified in the configuration file.
+    description: The Terraform version or version constraint specified in the configuration file.
     value: ${{ steps.main.outputs.required_version }}
 runs:
   using: composite

--- a/get-terraform-version/src/main.py
+++ b/get-terraform-version/src/main.py
@@ -4,34 +4,46 @@ import glob
 
 
 def get_directory():
-    return os.environ["directory"]
+    return os.environ.get("directory", ".")
 
 
-def get_required_version():
+def get_file():
+    return os.environ.get("file", "*.tf")
+
+
+def get_pattern():
+    return os.environ.get("pattern", r'^\s*required_version\s*=\s*"(.*?)"')
+
+
+def get_required_version() -> str:
     """
     Extract the 'required_version' from all Terraform files in a directory,
     skipping commented-out lines.
 
     :return: The 'required_version' found in the Terraform files
     """
-    directory = get_directory()  # Access "directory" here
+    directory = get_directory()
+    file = get_file()
+    pattern = get_pattern()
     required_version = None
 
-    # List all .tf files in the directory
-    tf_files = glob.glob(os.path.join(directory, "*.tf"))
+    # List all files matching the "file"-pattern in the directory
+    tf_files = glob.glob(os.path.join(directory, file))
 
     # Regular expression to match required_version, ignoring commented lines
     regex = re.compile(
-        r'^(?!\s*(#|//))\s*required_version\s*=\s*"(.*?)"',
+        pattern,
         re.MULTILINE
     )
 
     for file_path in tf_files:
         with open(file_path, "r") as file:
             content = file.read()
+            # remove comments from content
+            content = re.sub(r'(?m)^\s*#.*\n?', '', content)
             matches = regex.findall(content)
             for match in matches:
-                version = match[1]
+                version = match
                 print(f'::notice::Terraform version "{version}" found in "{file_path}"')
                 required_version = version
                 break
@@ -41,7 +53,7 @@ def get_required_version():
     return required_version
 
 
-def set_output(name, value):
+def set_output(name, value) -> None:
     with open(os.environ["GITHUB_OUTPUT"], "a") as file:
         print(f"Setting GitHub Actions output: {name}={value}")
         print(f"{name}={value}", file=file)

--- a/get-terraform-version/src/test_main.py
+++ b/get-terraform-version/src/test_main.py
@@ -105,3 +105,15 @@ def test_get_required_version_commented_versions(monkeypatch):
         with patch("glob.glob", return_value=["/mock/directory/valid.tf"]):
             result = get_required_version()
             assert result == ">= 1.9", "Should correctly parse required_version."
+
+# Test case: Valid .terraform-version file
+def test_terraform_version_from_terraform_version_file(monkeypatch):
+    monkeypatch.setenv("directory", "/mock/directory")
+    monkeypatch.setenv("file", ".terraform-version")
+    monkeypatch.setenv("pattern", r'^(.*)$')
+
+    tf_content = "1.9"
+    with patch("builtins.open", mock_open(read_data=tf_content)):
+        with patch("glob.glob", return_value=["/mock/directory/.terraform-version"]):
+            result = get_required_version()
+            assert result == "1.9", "Should correctly parse required_version."

--- a/get-terraform-version/src/test_main.py
+++ b/get-terraform-version/src/test_main.py
@@ -117,3 +117,23 @@ def test_terraform_version_from_terraform_version_file(monkeypatch):
         with patch("glob.glob", return_value=["/mock/directory/.terraform-version"]):
             result = get_required_version()
             assert result == "1.9", "Should correctly parse required_version."
+
+# Test case: Valid .tools-version (asdf) file
+def test_terraform_version_from_asdf_file(monkeypatch):
+    monkeypatch.setenv("directory", "/mock/directory")
+    # see: https://asdf-vm.com/manage/configuration.html
+    monkeypatch.setenv("file", ".tool-versions")
+    monkeypatch.setenv("pattern", r'^terraform (.*)$')
+
+    tf_content = """
+    ruby 2.5.3 # This is a comment
+    terraform 1.9
+    # This is another comment
+    nodejs 10.15.0
+    """
+    # trim content
+    tf_content = "\n".join([line.strip() for line in tf_content.split("\n")])
+    with patch("builtins.open", mock_open(read_data=tf_content)):
+        with patch("glob.glob", return_value=["/mock/directory/.tool-versions"]):
+            result = get_required_version()
+            assert result == "1.9", "Should correctly parse required_version."


### PR DESCRIPTION
This pull request includes significant updates to the `get-terraform-version` GitHub Action to increase its flexibility and functionality. The changes involve modifying the way the action identifies and extracts the Terraform version from configuration files, updating the documentation, and adding new test cases.

Enhancements to functionality:

* [`get-terraform-version/action.yaml`](diffhunk://#diff-6011406210cee5b6e28edf846e1eb4d20d145549c8de9b500702e009716acfbbL2-R15): Added new optional inputs `file` and `pattern` to specify the file pattern and regex pattern for extracting the Terraform version. Updated the description of the `directory` input to reflect these changes.
* [`get-terraform-version/src/main.py`](diffhunk://#diff-88fceb2371c0e70f9a6d534a1894f642410d1b99f21c0d38181aae672f5e08f0L7-R46): Refactored `get_required_version` to use the new `file` and `pattern` inputs. Improved version extraction by removing comments from the content before applying the regex pattern. [[1]](diffhunk://#diff-88fceb2371c0e70f9a6d534a1894f642410d1b99f21c0d38181aae672f5e08f0L7-R46) [[2]](diffhunk://#diff-88fceb2371c0e70f9a6d534a1894f642410d1b99f21c0d38181aae672f5e08f0L44-R56)

Documentation updates:

* [`get-terraform-version/README.md`](diffhunk://#diff-62d3a6887f77331d891c133c32b52b9caf39ee11a1b455425b118b35c9c33663L3-R7): Updated the inputs section to include the new `file` and `pattern` inputs. Modified usage examples to demonstrate how to use these new inputs. [[1]](diffhunk://#diff-62d3a6887f77331d891c133c32b52b9caf39ee11a1b455425b118b35c9c33663L3-R7) [[2]](diffhunk://#diff-62d3a6887f77331d891c133c32b52b9caf39ee11a1b455425b118b35c9c33663L20-R28) [[3]](diffhunk://#diff-62d3a6887f77331d891c133c32b52b9caf39ee11a1b455425b118b35c9c33663R59-R70)

Testing improvements:

* [`get-terraform-version/src/test_main.py`](diffhunk://#diff-f859dcfa7cc4ad3341f6794f2696b224c21b67fae346f09014ca19fa67f296a0R108-R119): Added a new test case to verify the correct parsing of the Terraform version from a `.terraform-version` file using the new `file` and `pattern` inputs.